### PR TITLE
Add the relevant website url to the outside pages

### DIFF
--- a/outside.html
+++ b/outside.html
@@ -76,13 +76,19 @@
                 border-top: 1px solid rgb(100, 100, 100);
             }
 
-            #progress > h1 {
-                font-size: 2.6em;
+            #progress > h1, #progress > h2 {
                 color: rgb(200, 200, 200);
                 margin: 0.1em 0.3em;
 
                 flex: 1 1 auto;
                 -webkit-flex: 1 1 auto;
+            }
+            #progress > h1 {
+                font-size: 2.6em;
+            }
+            #progress > h2 {
+                font-size: 1.7em;
+                font-style: italic;
             }
 
             #progress > sr-clock {
@@ -98,24 +104,29 @@
         <core-pages id="pages" selected="0">
             <sr-competitor-schedule
                 data-title="Schedule"
+                data-website-url-slug="schedule"
                 data-needs-comp
             ></sr-competitor-schedule>
             <sr-leaderboard
                 data-title="League Leaderboard"
+                data-website-url-slug="league"
                 data-needs-comp
             ></sr-leaderboard>
             <sr-scores
                 data-title="League Scores"
+                data-website-url-slug="league"
                 data-needs-comp
             ></sr-scores>
             <sr-knockout-diagram
                 data-title="Knockouts"
+                data-website-url-slug="knockout"
                 data-needs-comp
             ></sr-knockout-diagram>
         </core-pages>
 
         <sr-progress id="progress" progress="1">
             <h1 id="progress-title"></h1>
+            <h2 id="website-url"></h2>
             <sr-clock></sr-clock>
         </sr-progress>
 
@@ -144,10 +155,12 @@
                 var pages = document.querySelector('#pages');
                 var progress = document.querySelector('#progress');
                 var progressTitle = document.querySelector('#progress-title');
+                var websiteUrl = document.querySelector('#website-url');
 
                 var nextPage = function() {
                     pages.selected = (pages.selected + 1) % pages.children.length;
                     progressTitle.textContent = pages.children[pages.selected].dataset.title;
+                    websiteUrl.textContent = "srobo.org/comp/" + pages.children[pages.selected].dataset.websiteUrlSlug;
                     progress.progress = 0;
                 };
 

--- a/outside.html
+++ b/outside.html
@@ -96,10 +96,22 @@
         <sr-comp id="comp"></sr-comp>
 
         <core-pages id="pages" selected="0">
-            <sr-competitor-schedule data-title="Schedule" data-needs-comp></sr-competitor-schedule>
-            <sr-leaderboard data-title="League Leaderboard" data-needs-comp></sr-leaderboard>
-            <sr-scores data-title="League Scores" data-needs-comp></sr-scores>
-            <sr-knockout-diagram data-title="Knockouts" data-needs-comp></sr-knockout-diagram>
+            <sr-competitor-schedule
+                data-title="Schedule"
+                data-needs-comp
+            ></sr-competitor-schedule>
+            <sr-leaderboard
+                data-title="League Leaderboard"
+                data-needs-comp
+            ></sr-leaderboard>
+            <sr-scores
+                data-title="League Scores"
+                data-needs-comp
+            ></sr-scores>
+            <sr-knockout-diagram
+                data-title="Knockouts"
+                data-needs-comp
+            ></sr-knockout-diagram>
         </core-pages>
 
         <sr-progress id="progress" progress="1">

--- a/outside.html
+++ b/outside.html
@@ -76,7 +76,7 @@
                 border-top: 1px solid rgb(100, 100, 100);
             }
 
-            #progress > h1, #progress > h2 {
+            #progress > h1, #progress > p {
                 color: rgb(200, 200, 200);
                 margin: 0.1em 0.3em;
 
@@ -86,7 +86,7 @@
             #progress > h1 {
                 font-size: 2.6em;
             }
-            #progress > h2 {
+            #progress > p {
                 font-size: 1.7em;
                 font-style: italic;
             }
@@ -126,7 +126,7 @@
 
         <sr-progress id="progress" progress="1">
             <h1 id="progress-title"></h1>
-            <h2 id="website-url"></h2>
+            <p id="website-url"></p>
             <sr-clock></sr-clock>
         </sr-progress>
 


### PR DESCRIPTION
We've observed people taking photos of these screens, yet the information is more conveniently available on the website. This hopefully advertises that.

Fixes https://github.com/PeterJCLaw/srcomp-screens/issues/8
